### PR TITLE
one use only guns

### DIFF
--- a/Content.Shared/Weapons/Ranged/Components/MagazineAmmoProviderComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/MagazineAmmoProviderComponent.cs
@@ -17,4 +17,13 @@ public partial class MagazineAmmoProviderComponent : AmmoProviderComponent
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("autoEject")]
     public bool AutoEject = false;
+
+    /// <summary>
+    /// Should this not be possible to reload?
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField("oneUseOnly")]
+    public bool oneUseOnly = false;
+
+    //wether this was already used or not.
+    public bool used = false;
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Magazine.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Magazine.cs
@@ -145,9 +145,10 @@ public abstract partial class SharedGunSystem
 
     private void FinaliseMagazineTakeAmmo(EntityUid uid, MagazineAmmoProviderComponent component, int count, int capacity, EntityUid? user, AppearanceComponent? appearance)
     {
-        // If no ammo then check for autoeject
-        if (component.AutoEject && count == 0)
+        // If no ammo then check for autoeject AND one use only
+        if ((component.AutoEject || component.oneUseOnly) && count == 0 || component.used)
         {
+            component.used = true;
             EjectMagazine(uid, component);
             Audio.PlayPredicted(component.SoundAutoEject, uid, user);
         }


### PR DESCRIPTION
enable the `oneUseOnly` on the gun's  MagazineAmmoProviderComponent magazine component


## About the PR
<!-- What did you change in this PR? -->
look in the fucking files buddy
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Why / Balance
so you can have le epic one use guns. saibapunko.
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## How to test
add and enable the `oneUseOnly` boolean to the desired gun's MagazineAmmoProviderComponent
it has to be a gun that uses a magazine, not a chamber

Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: one use guns
-->
