### PR TITLE
added species requirements support for jobs

### DIFF
--- a/Content.Shared/Preferences/Loadouts/Effects/JobRequirementLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/JobRequirementLoadoutEffect.cs
@@ -4,6 +4,7 @@ using Content.Shared.Roles;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
+using Content.Shared.Players;
 
 namespace Content.Shared.Preferences.Loadouts.Effects;
 
@@ -17,11 +18,12 @@ public sealed partial class JobRequirementLoadoutEffect : LoadoutEffect
 
     public override bool Validate(RoleLoadout loadout, ICommonSession session, IDependencyCollection collection, [NotNullWhen(false)] out FormattedMessage? reason)
     {
-        var manager = collection.Resolve<ISharedPlaytimeManager>();
-        var playtimes = manager.GetPlayTimes(session);
+        var playtimes = collection.Resolve<ISharedPlaytimeManager>().GetPlayTimes(session);
+
         return JobRequirements.TryRequirementMet(Requirement, playtimes, out reason,
             collection.Resolve<IEntityManager>(),
             collection.Resolve<IPrototypeManager>(),
-            true); // Frontier: for now we just let assume whitelist? TODO: implement white list
+            true, // Frontier: for now we just let assume whitelist? TODO: implement white list
+            null);
     }
 }

--- a/Resources/Locale/en-US/_Crescent/job/job-requirements.ftl
+++ b/Resources/Locale/en-US/_Crescent/job/job-requirements.ftl
@@ -1,0 +1,1 @@
+job-requirement-species-not-allowed = Your species [color=yellow]{$species}[/color] is not allowed for this role.


### PR DESCRIPTION
![image](https://github.com/ilikeships/Sector-Crescent/assets/5463623/ff250904-195f-434b-a75e-1263556bae04)
Add either `allowedOnly` or `notAllowed` requirements to a job to set species requirements
`allowedOnly` will always overrule `notAllowed`, so add only one of them
`allowedOnly`: Allow only these species, all other species are forbidden
`notAllowed`: Do not allow these species, all other species are allowed