### PR TITLE
Add SignalControl component and SignalControl precondition to AI behaviours

### DIFF
--- a/Content.Server/DeviceLinking/Components/SignalControlComponent.cs
+++ b/Content.Server/DeviceLinking/Components/SignalControlComponent.cs
@@ -1,0 +1,25 @@
+using Content.Server.DeviceLinking.Systems;
+using Content.Shared.DeviceLinking;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.DeviceLinking.Components
+{
+    /// <summary>
+    /// A component with an On/Off state controlled by signals from DeviceLinking
+    /// </summary>
+    [RegisterComponent, Access(typeof(SignalControlSystem))]
+    public sealed partial class SignalControlComponent : Component
+    {
+        [DataField]
+        public ProtoId<SinkPortPrototype> TogglePort = "Toggle";
+
+        [DataField]
+        public ProtoId<SinkPortPrototype> OnPort = "On";
+
+        [DataField]
+        public ProtoId<SinkPortPrototype> OffPort = "Off";
+
+        [ViewVariables(VVAccess.ReadWrite)]
+        public bool IsOn = false;
+    }
+}

--- a/Content.Server/DeviceLinking/Components/SignalControlComponent.cs
+++ b/Content.Server/DeviceLinking/Components/SignalControlComponent.cs
@@ -19,6 +19,9 @@ namespace Content.Server.DeviceLinking.Components
         [DataField]
         public ProtoId<SinkPortPrototype> OffPort = "Off";
 
+        [DataField("isOnByDefault")]
+        public bool IsOnByDefault = false;
+
         [ViewVariables(VVAccess.ReadWrite)]
         public bool IsOn = false;
     }

--- a/Content.Server/DeviceLinking/Systems/SignalControlSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/SignalControlSystem.cs
@@ -16,6 +16,7 @@ namespace Content.Server.DeviceLinking.Systems
         private void OnInit(EntityUid uid, SignalControlComponent control, ref MapInitEvent args)
         {
             _signalSystem.EnsureSinkPorts(uid, control.TogglePort, control.OnPort, control.OffPort);
+            control.IsOn = control.IsOnByDefault;
         }
 
         private void OnSignalReceived(EntityUid uid, SignalControlComponent control, ref SignalReceivedEvent args)

--- a/Content.Server/DeviceLinking/Systems/SignalControlSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/SignalControlSystem.cs
@@ -1,0 +1,37 @@
+using Content.Server.DeviceLinking.Components;
+using Content.Server.DeviceLinking.Events;
+
+namespace Content.Server.DeviceLinking.Systems
+{
+    public sealed class SignalControlSystem : EntitySystem
+    {
+        [Dependency] private readonly DeviceLinkSystem _signalSystem = default!;
+
+        public override void Initialize()
+        {
+            SubscribeLocalEvent<SignalControlComponent, MapInitEvent>(OnInit);
+            SubscribeLocalEvent<SignalControlComponent, SignalReceivedEvent>(OnSignalReceived);
+        }
+
+        private void OnInit(EntityUid uid, SignalControlComponent control, ref MapInitEvent args)
+        {
+            _signalSystem.EnsureSinkPorts(uid, control.TogglePort, control.OnPort, control.OffPort);
+        }
+
+        private void OnSignalReceived(EntityUid uid, SignalControlComponent control, ref SignalReceivedEvent args)
+        {
+            if (args.Port == control.TogglePort)
+            {
+                control.IsOn = !control.IsOn;
+            }
+            else if (args.Port == control.OnPort)
+            {
+                control.IsOn = true;
+            }
+            else if (args.Port == control.OffPort)
+            {
+                control.IsOn = false;
+            }
+        }
+    }
+}

--- a/Content.Server/NPC/HTN/Preconditions/SignalControlPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/SignalControlPrecondition.cs
@@ -1,0 +1,25 @@
+using Content.Server.DeviceLinking.Components;
+
+namespace Content.Server.NPC.HTN.Preconditions
+{
+    /// <summary>
+    /// Returns true if the entity has a SignalControl component in On state
+    /// </summary>
+    public sealed partial class SignalControlPrecondition : HTNPrecondition
+    {
+        [Dependency] private readonly IEntityManager _entManager = default!;
+
+        public override bool IsMet(NPCBlackboard blackboard)
+        {
+            if (blackboard.TryGetValue<EntityUid>(NPCBlackboard.Owner, out var owner, _entManager))
+            {
+                if (_entManager.TryGetComponent<SignalControlComponent>(owner, out var control))
+                {
+                    return control.IsOn;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Resources/Prototypes/_Crescent/Entities/turrets.yml
+++ b/Resources/Prototypes/_Crescent/Entities/turrets.yml
@@ -74,7 +74,7 @@
       capacity: 25000
     - type: HTN
       rootTask:
-        task: TurretCompound #npcroot
+        task: PDTTurretCompound #npcroot
       blackboard:
         RotateSpeed: !type:Single
           3.141
@@ -82,9 +82,19 @@
           65
         VisionRadius: !type:Single
           65
-    
         SoundTargetInLOS: !type:SoundPathSpecifier
           path: /Audio/Effects/double_beep.ogg
+    - type: SignalControl
+    - type: DeviceNetwork
+      deviceNetId: Wireless
+      receiveFrequencyId: BasicDevice
+    - type: WirelessNetworkConnection
+      range: 700
+    - type: DeviceLinkSink
+      ports:
+        - Toggle
+        - On
+        - Off
     - type: MouseRotator
       angleTolerance: 5
       rotationSpeed: 180

--- a/Resources/Prototypes/_Crescent/Entities/turrets.yml
+++ b/Resources/Prototypes/_Crescent/Entities/turrets.yml
@@ -85,6 +85,7 @@
         SoundTargetInLOS: !type:SoundPathSpecifier
           path: /Audio/Effects/double_beep.ogg
     - type: SignalControl
+      isOnByDefault: true
     - type: DeviceNetwork
       deviceNetId: Wireless
       receiveFrequencyId: BasicDevice

--- a/Resources/Prototypes/_Crescent/npcroot.yml
+++ b/Resources/Prototypes/_Crescent/npcroot.yml
@@ -7,9 +7,10 @@
         - !type:HTNPrimitiveTask
           operator: !type:UtilityOperator
             proto: NearbyGunTargets
-        
+
         - !type:HTNPrimitiveTask
           preconditions:
+            - !type:SignalControlPrecondition
             - !type:KeyExistsPrecondition
               key: Target
             - !type:TargetInRangePrecondition


### PR DESCRIPTION
**SignalControl** is a generic component with an On/Off state controlled by signals. It provides the IsOn state to be used by other components.
It can be configured to be On by default with `isOnByDefault`.
To add it to a prototype, it should look like this (wireless components are optional):
![image](https://github.com/ilikeships/Sector-Crescent/assets/5463623/2bcb98f1-7655-4e4f-bbb1-758ead68d62a)

**SignalControlPrecondition** is an AI behaviour precondition that requires the entity to have a SignalControl component with IsOn being true.
The entity must have the SignalControl component on it, and the component's IsOn state must be true.
![image](https://github.com/ilikeships/Sector-Crescent/assets/5463623/f21e1d9d-e5b6-4b42-a036-2a8cbe9e3353)
