### PR TITLE
Added Powered precondition to AI behaviours

### DIFF
--- a/Content.Server/NPC/HTN/Preconditions/PoweredPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/PoweredPrecondition.cs
@@ -20,9 +20,11 @@ namespace Content.Server.NPC.HTN.Preconditions
                 {
                     return apcPowerReceiver.Powered;
                 }
+
+                return PoweredIfNoPowerReceiver;
             }
 
-            return PoweredIfNoPowerReceiver;
+            return false;
         }
     }
 }

--- a/Content.Server/NPC/HTN/Preconditions/PoweredPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/PoweredPrecondition.cs
@@ -1,0 +1,28 @@
+using Content.Server.Power.Components;
+
+namespace Content.Server.NPC.HTN.Preconditions
+{
+    /// <summary>
+    /// Returns true if the entity has an ApcPowerReceiver component in Powered state
+    /// </summary>
+    public sealed partial class PoweredPrecondition : HTNPrecondition
+    {
+        [Dependency] private readonly IEntityManager _entManager = default!;
+
+        [DataField("poweredIfNoPowerReceiver")]
+        public bool PoweredIfNoPowerReceiver = false;
+
+        public override bool IsMet(NPCBlackboard blackboard)
+        {
+            if (blackboard.TryGetValue<EntityUid>(NPCBlackboard.Owner, out var owner, _entManager))
+            {
+                if (_entManager.TryGetComponent<ApcPowerReceiverComponent>(owner, out var apcPowerReceiver))
+                {
+                    return apcPowerReceiver.Powered;
+                }
+            }
+
+            return PoweredIfNoPowerReceiver;
+        }
+    }
+}

--- a/Content.Server/NPC/HTN/Preconditions/SignalControlPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/SignalControlPrecondition.cs
@@ -20,9 +20,11 @@ namespace Content.Server.NPC.HTN.Preconditions
                 {
                     return control.IsOn;
                 }
+
+                return IsOnIfNoSignalControl;
             }
 
-            return IsOnIfNoSignalControl;
+            return false;
         }
     }
 }

--- a/Content.Server/NPC/HTN/Preconditions/SignalControlPrecondition.cs
+++ b/Content.Server/NPC/HTN/Preconditions/SignalControlPrecondition.cs
@@ -9,6 +9,9 @@ namespace Content.Server.NPC.HTN.Preconditions
     {
         [Dependency] private readonly IEntityManager _entManager = default!;
 
+        [DataField("isOnIfNoSignalControl")]
+        public bool IsOnIfNoSignalControl = false;
+
         public override bool IsMet(NPCBlackboard blackboard)
         {
             if (blackboard.TryGetValue<EntityUid>(NPCBlackboard.Owner, out var owner, _entManager))
@@ -19,7 +22,7 @@ namespace Content.Server.NPC.HTN.Preconditions
                 }
             }
 
-            return false;
+            return IsOnIfNoSignalControl;
         }
     }
 }

--- a/Resources/Prototypes/_Crescent/Entities/turrets.yml
+++ b/Resources/Prototypes/_Crescent/Entities/turrets.yml
@@ -96,6 +96,8 @@
         - Toggle
         - On
         - Off
+    - type: ApcPowerReceiver
+      powerLoad: 6000
     - type: MouseRotator
       angleTolerance: 5
       rotationSpeed: 180

--- a/Resources/Prototypes/_Crescent/npcroot.yml
+++ b/Resources/Prototypes/_Crescent/npcroot.yml
@@ -3,14 +3,16 @@
 - type: htnCompound
   id: PDTTurretCompound
   branches:
-    - tasks:
+    - preconditions:
+        - !type:PoweredPrecondition
+        - !type:SignalControlPrecondition
+      tasks:
         - !type:HTNPrimitiveTask
           operator: !type:UtilityOperator
             proto: NearbyGunTargets
 
         - !type:HTNPrimitiveTask
           preconditions:
-            - !type:SignalControlPrecondition
             - !type:KeyExistsPrecondition
               key: Target
             - !type:TargetInRangePrecondition
@@ -29,6 +31,8 @@
               proto: NearbyGunTargets
               key: Target
 
-    - tasks:
+    - preconditions:
+        - !type:PoweredPrecondition
+      tasks:
         - !type:HTNCompoundTask
           task: IdleSpinCompound


### PR DESCRIPTION
**PoweredPrecondition** is an AI behaviour precondition that requires the entity to have an ApcPowerReceiver that is being Powered. The ApcPowerReceiver must have its power load met to have Powered be true.
You can also set `poweredIfNoPowerReceiver: true` to make the precondition to always be true if the ApcPowerReceiver is not present on the prototype or removed from the entity.

Also added a similar `isOnIfNoSignalControl` functionality to **SignalControlPrecondition**