### PR TITLE
Add preconditions to AI behaviour operators

### DIFF
--- a/Content.Server/NPC/HTN/HTNSystem.cs
+++ b/Content.Server/NPC/HTN/HTNSystem.cs
@@ -351,7 +351,33 @@ public sealed class HTNSystem : EntitySystem
                 component.CheckServices = false;
             }
 
-            status = currentOperator.Update(blackboard, frameTime);
+            if (currentOperator.Preconditions != null)
+            {
+                bool valid = true;
+                foreach (var precondition in currentOperator.Preconditions)
+                {
+                    if (precondition.IsMet(blackboard))
+                    {
+                        continue;
+                    }
+
+                    valid = false;
+                    break;
+                }
+
+                if (valid)
+                {
+                    status = currentOperator.Update(blackboard, frameTime);
+                }
+                else
+                {
+                    status = HTNOperatorStatus.Failed;
+                }
+            }
+            else
+            {
+                status = currentOperator.Update(blackboard, frameTime);
+            }
 
             switch (status)
             {

--- a/Content.Server/NPC/HTN/PrimitiveTasks/HTNOperator.cs
+++ b/Content.Server/NPC/HTN/PrimitiveTasks/HTNOperator.cs
@@ -1,6 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Content.Server.NPC.HTN.Preconditions;
 
 namespace Content.Server.NPC.HTN.PrimitiveTasks;
 
@@ -11,11 +12,24 @@ namespace Content.Server.NPC.HTN.PrimitiveTasks;
 public abstract partial class HTNOperator
 {
     /// <summary>
+    /// What needs to be true for this operator to run or keep running.
+    /// </summary>
+    [DataField("preconditions")] public List<HTNPrecondition>? Preconditions = null;
+
+    /// <summary>
     /// Called once whenever prototypes reload. Typically used to inject dependencies.
     /// </summary>
     public virtual void Initialize(IEntitySystemManager sysManager)
     {
         IoCManager.InjectDependencies(this);
+
+        if (Preconditions != null)
+        {
+            foreach (var precondition in Preconditions)
+            {
+                precondition.Initialize(sysManager);
+            }
+        }
     }
 
     /// <summary>

--- a/Resources/Prototypes/_Crescent/npcroot.yml
+++ b/Resources/Prototypes/_Crescent/npcroot.yml
@@ -25,6 +25,9 @@
               targetKey: Target
               rangeKey: PDTRange
           operator: !type:GunOperator
+            preconditions:
+              - !type:PoweredPrecondition
+              - !type:SignalControlPrecondition
             targetKey: Target
             requireLOS: false
           services:


### PR DESCRIPTION
Operators can now have preconditions that are checked every update.
Add them to the operator definition like so:
![image](https://github.com/ilikeships/Sector-Crescent/assets/5463623/870edae6-f2a1-4ee8-8e54-2269ed433ad1)
